### PR TITLE
Fix running in quiet mode

### DIFF
--- a/src/LicenseChecker.php
+++ b/src/LicenseChecker.php
@@ -65,7 +65,7 @@ final class LicenseChecker extends SingleCommandApplication
             return self::FAILURE;
         }
 
-        $process = Process::fromShellCommandline('composer licenses --format=json', $path);
+        $process = Process::fromShellCommandline('SHELL_VERBOSITY=0 composer licenses --format=json', $path);
         $process->run();
         if (!$process->isSuccessful()) {
             $style->error(\sprintf('Failed to run "composer licenses --format=json" (%d).', $process->getExitCode()));


### PR DESCRIPTION
If, for some reason, one decides to run in quiet mode and cares only for the exit code, the command currently fails as `SHELL_VERBOSITY` is put into and read from env, resulting in `composer licenses` outputting nothing:

```
In LicenseChecker.php line 65:
                
  Syntax error  
```

This PR overrides the `SHELL_VERBOSITY` for composer process.