### PR TITLE
Show used allow file and scanned path in verbose mode

### DIFF
--- a/src/LicenseChecker.php
+++ b/src/LicenseChecker.php
@@ -73,6 +73,9 @@ final class LicenseChecker extends SingleCommandApplication
             return self::FAILURE;
         }
 
+        $style->writeln(\sprintf('Checking project at: %s', \realpath($path ?? \dirname(__DIR__))), OutputInterface::VERBOSITY_VERBOSE);
+        $style->writeln(\sprintf('Using allow file: %s', \realpath($allowFile)), OutputInterface::VERBOSITY_VERBOSE);
+
         $rawData = $process->getOutput();
 
         /** @var array{

--- a/tests/data/lendable_allowed.php
+++ b/tests/data/lendable_allowed.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Lendable\ComposerLicenseChecker\LicenseConfigurationBuilder;
-
-return (new LicenseConfigurationBuilder())
-    ->addAllowedVendor('lendable')
-    ->build();


### PR DESCRIPTION
Adds useless info in verbose (`-v`) mode.

<details>
  <summary>Output with -v and default --path</summary>

```sh
Composer License Checker
========================

Checking project at: /home/kokos/composer-license-checker
Using allow file: /home/kapusta/composer-license-checker/.allowed-licenses.php
```
</details>

<details>
  <summary>Output with -v and --path=tests/data</summary>

```sh
Composer License Checker
========================

Checking project at: /home/japko/composer-license-checker/tests/data
Using allow file: /home/cebula/composer-license-checker/.allowed-licenses.php
```
</details>