### PR TITLE
Add test that SHELL_VERBOSITY isn't inherited by sub-execution of composer commands

### DIFF
--- a/tests/e2e/ComposerLicensesLicenseCheckerTest.php
+++ b/tests/e2e/ComposerLicensesLicenseCheckerTest.php
@@ -7,11 +7,24 @@ namespace Tests\E2E\Lendable\ComposerLicenseChecker;
 use Lendable\ComposerLicenseChecker\ComposerRunner\SymfonyProcessComposerRunner;
 use Lendable\ComposerLicenseChecker\PackagesProvider;
 use Lendable\ComposerLicenseChecker\PackagesProvider\ComposerLicensesPackagesProvider;
+use Tests\Support\Lendable\ComposerLicenseChecker\CommandTesterAsserter;
+use Tests\Support\Lendable\ComposerLicenseChecker\LicenseConfigurationFileBuilder;
 
 final class ComposerLicensesLicenseCheckerTest extends LicenseCheckerCase
 {
     protected function packagesProvider(): PackagesProvider
     {
         return new ComposerLicensesPackagesProvider(new SymfonyProcessComposerRunner());
+    }
+
+    public function test_verbose_mode_doesnt_impact_composer_execution(): void
+    {
+        $handle = $this->createTempFile();
+        $allowFile = LicenseConfigurationFileBuilder::create($handle)->withAllowedPackage('lendable/unlicensed')->build();
+
+        $this->commandTester->execute(['--allow-file' => $allowFile, '--path' => 'tests/data/with_unlicensed', '-vvv' => true]);
+
+        CommandTesterAsserter::assertThat($this->commandTester)
+            ->hasStatusCode(0);
     }
 }

--- a/tests/e2e/LicenseCheckerCase.php
+++ b/tests/e2e/LicenseCheckerCase.php
@@ -9,15 +9,15 @@ use Lendable\ComposerLicenseChecker\LicenseChecker;
 use Lendable\ComposerLicenseChecker\LicenseConfiguration;
 use Lendable\ComposerLicenseChecker\PackagesProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Support\Lendable\ComposerLicenseChecker\CommandTesterAsserter;
 use Tests\Support\Lendable\ComposerLicenseChecker\LicenseConfigurationFileBuilder;
+use Tests\Support\Lendable\ComposerLicenseChecker\SingleCommandApplicationTester;
 
 abstract class LicenseCheckerCase extends TestCase
 {
-    private CommandTester $commandTester;
+    protected SingleCommandApplicationTester $commandTester;
 
-    private string $path = 'tests'.\DIRECTORY_SEPARATOR.'data'.\DIRECTORY_SEPARATOR.'default'.\DIRECTORY_SEPARATOR;
+    protected string $path = 'tests'.\DIRECTORY_SEPARATOR.'data'.\DIRECTORY_SEPARATOR.'default'.\DIRECTORY_SEPARATOR;
 
     protected function setUp(): void
     {
@@ -28,7 +28,7 @@ abstract class LicenseCheckerCase extends TestCase
         );
         $command->setAutoExit(false);
 
-        $this->commandTester = new CommandTester($command);
+        $this->commandTester = new SingleCommandApplicationTester($command);
     }
 
     abstract protected function packagesProvider(): PackagesProvider;
@@ -227,7 +227,7 @@ abstract class LicenseCheckerCase extends TestCase
     /**
      * @return resource
      */
-    private function createTempFile(): mixed
+    final protected function createTempFile(): mixed
     {
         $handle = \tmpfile();
 

--- a/tests/support/CommandTesterAsserter.php
+++ b/tests/support/CommandTesterAsserter.php
@@ -10,11 +10,11 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 final class CommandTesterAsserter
 {
-    private function __construct(private readonly CommandTester $commandTester)
+    private function __construct(private readonly SingleCommandApplicationTester|CommandTester $commandTester)
     {
     }
 
-    public static function assertThat(CommandTester $commandTester): self
+    public static function assertThat(SingleCommandApplicationTester|CommandTester $commandTester): self
     {
         return new self($commandTester);
     }

--- a/tests/support/SingleCommandApplicationTester.php
+++ b/tests/support/SingleCommandApplicationTester.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Lendable\ComposerLicenseChecker;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class SingleCommandApplicationTester
+{
+    private readonly CommandTester $commandTester;
+
+    public function __construct(SingleCommandApplication $command)
+    {
+        $this->commandTester = new CommandTester($command);
+    }
+
+    /**
+     * @param array<mixed> $input
+     * @param array<mixed> $options
+     */
+    public function execute(array $input, array $options = []): int
+    {
+        $prevShellVerbosity = \getenv('SHELL_VERBOSITY');
+
+        try {
+            return $this->commandTester->execute($input, $options);
+        } finally {
+            // Seems like Symfony goes to efforts to reset SHELL_VERBOSITY when using ApplicationTester, but not for CommandTester
+            // this leaves the env var set and further test case execution will have that SHELL_VERBOSITY setting.
+            if (false === $prevShellVerbosity) {
+                @\putenv('SHELL_VERBOSITY');
+                unset($_ENV['SHELL_VERBOSITY'], $_SERVER['SHELL_VERBOSITY']);
+            } else {
+                @\putenv('SHELL_VERBOSITY='.$prevShellVerbosity);
+                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity;
+                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity;
+            }
+        }
+    }
+
+    public function getDisplay(bool $normalize = false): string
+    {
+        return $this->commandTester->getDisplay($normalize);
+    }
+
+    public function getErrorOutput(bool $normalize = false): string
+    {
+        return $this->commandTester->getErrorOutput($normalize);
+    }
+
+    public function getInput(): InputInterface
+    {
+        return $this->commandTester->getInput();
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->commandTester->getOutput();
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->commandTester->getStatusCode();
+    }
+
+    public function assertCommandIsSuccessful(string $message = ''): void
+    {
+        $this->commandTester->assertCommandIsSuccessful($message);
+    }
+}


### PR DESCRIPTION
I've had to add test support code to manage resetting `SHELL_VERBOSITY`. It appears Symfony's `ApplicationTester` has logic to reset this value after an application is run, but `CommandTester` makes no attempts to. I assume this is just an oversight and `SingleCommandApplication` wasn't taken into consideration.

`ApplicationTester` does:

```php
    public function run(array $input, array $options = []): int
    {
        $prevShellVerbosity = getenv('SHELL_VERBOSITY');

        try {
            $this->input = new ArrayInput($input);
            if (isset($options['interactive'])) {
                $this->input->setInteractive($options['interactive']);
            }

            if ($this->inputs) {
                $this->input->setStream(self::createStream($this->inputs));
            }

            $this->initOutput($options);

            return $this->statusCode = $this->application->run($this->input, $this->output);
        } finally {
            // SHELL_VERBOSITY is set by Application::configureIO so we need to unset/reset it
            // to its previous value to avoid one test's verbosity to spread to the following tests
            if (false === $prevShellVerbosity) {
                if (\function_exists('putenv')) {
                    @putenv('SHELL_VERBOSITY');
                }
                unset($_ENV['SHELL_VERBOSITY']);
                unset($_SERVER['SHELL_VERBOSITY']);
            } else {
                if (\function_exists('putenv')) {
                    @putenv('SHELL_VERBOSITY='.$prevShellVerbosity);
                }
                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity;
                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity;
            }
        }
    }
```