### PR TITLE
Improve package name validation re empty strings and explode

### DIFF
--- a/src/PackageName.php
+++ b/src/PackageName.php
@@ -26,11 +26,7 @@ final class PackageName
     public function __construct(string $packageName)
     {
         $data = \explode('/', $packageName);
-        if (\count($data) !== 2) {
-            throw InvalidPackageName::for($packageName);
-        }
-
-        if ($data[0] === '' || $data[1] === '') {
+        if (\count($data) !== 2 || $data[0] === '' || $data[1] === '') {
             throw InvalidPackageName::for($packageName);
         }
 

--- a/src/PackageName.php
+++ b/src/PackageName.php
@@ -30,8 +30,7 @@ final class PackageName
             throw InvalidPackageName::for($packageName);
         }
 
-        $this->vendor = $data[0];
-        $this->project = $data[1];
+        [$this->vendor, $this->project] = $data;
     }
 
     /**

--- a/src/PackageName.php
+++ b/src/PackageName.php
@@ -8,8 +8,14 @@ use Lendable\ComposerLicenseChecker\Exception\InvalidPackageName;
 
 final class PackageName
 {
+    /**
+     * @var non-empty-string
+     */
     public readonly string $vendor;
 
+    /**
+     * @var non-empty-string
+     */
     public readonly string $project;
 
     /**
@@ -24,9 +30,17 @@ final class PackageName
             throw InvalidPackageName::for($packageName);
         }
 
-        [$this->vendor, $this->project] = $data;
+        if ($data[0] === '' || $data[1] === '') {
+            throw InvalidPackageName::for($packageName);
+        }
+
+        $this->vendor = $data[0];
+        $this->project = $data[1];
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function toString(): string
     {
         return \sprintf('%s/%s', $this->vendor, $this->project);

--- a/tests/unit/PackageNameTest.php
+++ b/tests/unit/PackageNameTest.php
@@ -39,5 +39,8 @@ final class PackageNameTest extends TestCase
         yield 'empty' => [' '];
         yield 'vendor only' => ['vendor'];
         yield 'too many parts' => ['vendor/name/subname'];
+        yield 'only a /' => ['/'];
+        yield 'vendor/' => ['vendor/'];
+        yield '/package' => ['/package'];
     }
 }


### PR DESCRIPTION
The 3 added tests cases previously did not result in `InvalidPackageName`.