### PR TITLE
Fix a bug with a disjunctive license

### DIFF
--- a/src/Event/PackageWithViolatingLicense.php
+++ b/src/Event/PackageWithViolatingLicense.php
@@ -8,10 +8,7 @@ use Lendable\ComposerLicenseChecker\Package;
 
 final class PackageWithViolatingLicense implements Event
 {
-    /**
-     * @param non-empty-string $license
-     */
-    public function __construct(public readonly Package $package, public readonly string $license)
+    public function __construct(public readonly Package $package)
     {
     }
 }

--- a/src/LicenseChecker.php
+++ b/src/LicenseChecker.php
@@ -167,21 +167,19 @@ final class LicenseChecker extends SingleCommandApplication
                 continue;
             }
 
-            if ($package->licenses === []) {
+            if ($package->licenses->isEmpty()) {
                 $violation = true;
                 $this->dispatcher->dispatch(new UnlicensedPackageNotExplicitlyAllowed($package));
 
                 continue;
             }
 
-            foreach ($package->licenses as $license) {
-                if ($config->allowsLicense($license)) {
-                    continue;
-                }
-
-                $violation = true;
-                $this->dispatcher->dispatch(new PackageWithViolatingLicense($package, $license));
+            if ($config->allowsLicenseOfPackage($package)) {
+                continue;
             }
+
+            $violation = true;
+            $this->dispatcher->dispatch(new PackageWithViolatingLicense($package));
         }
 
         if ($violation) {

--- a/src/LicenseChecker.php
+++ b/src/LicenseChecker.php
@@ -167,7 +167,7 @@ final class LicenseChecker extends SingleCommandApplication
                 continue;
             }
 
-            if ($package->licenses->isEmpty()) {
+            if ($package->isUnlicensed()) {
                 $violation = true;
                 $this->dispatcher->dispatch(new UnlicensedPackageNotExplicitlyAllowed($package));
 

--- a/src/LicenseConfiguration.php
+++ b/src/LicenseConfiguration.php
@@ -17,9 +17,15 @@ final class LicenseConfiguration
     ) {
     }
 
-    public function allowsLicense(string $license): bool
+    public function allowsLicenseOfPackage(Package $package): bool
     {
-        return \in_array($license, $this->allowedLicenses, true);
+        foreach ($package->licenses as $license) {
+            if ($this->allowsLicense($license)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function allowsPackage(string $package): bool
@@ -31,5 +37,10 @@ final class LicenseConfiguration
         }
 
         return false;
+    }
+
+    private function allowsLicense(string $license): bool
+    {
+        return \in_array($license, $this->allowedLicenses, true);
     }
 }

--- a/src/Licenses.php
+++ b/src/Licenses.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lendable\ComposerLicenseChecker;
+
+/**
+ * @implements \IteratorAggregate<int, string>
+ */
+final class Licenses implements \IteratorAggregate
+{
+    /**
+     * @param list<non-empty-string> $licenses
+     */
+    public function __construct(
+        private readonly array $licenses,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \implode(', ', $this->licenses);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->licenses === [];
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->licenses;
+    }
+}

--- a/src/Licenses.php
+++ b/src/Licenses.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lendable\ComposerLicenseChecker;
 
-use ArrayIterator;
-
 /**
  * @implements \IteratorAggregate<int, string>
  */
@@ -31,6 +29,6 @@ final class Licenses implements \IteratorAggregate
 
     public function getIterator(): \Traversable
     {
-        return new ArrayIterator($this->licenses);
+        return new \ArrayIterator($this->licenses);
     }
 }

--- a/src/Licenses.php
+++ b/src/Licenses.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lendable\ComposerLicenseChecker;
 
+use ArrayIterator;
+
 /**
  * @implements \IteratorAggregate<int, string>
  */
@@ -29,6 +31,6 @@ final class Licenses implements \IteratorAggregate
 
     public function getIterator(): \Traversable
     {
-        yield from $this->licenses;
+        return new ArrayIterator($this->licenses);
     }
 }

--- a/src/Licenses.php
+++ b/src/Licenses.php
@@ -31,4 +31,9 @@ final class Licenses implements \IteratorAggregate
     {
         return new \ArrayIterator($this->licenses);
     }
+
+    public function isDisjunctive(): bool
+    {
+        return \count($this->licenses) > 1;
+    }
 }

--- a/src/Output/Display.php
+++ b/src/Output/Display.php
@@ -19,10 +19,7 @@ interface Display
 
     public function onOutcomeSuccess(): void;
 
-    /**
-     * @param non-empty-string $license
-     */
-    public function onPackageWithViolatingLicense(Package $package, string $license): void;
+    public function onPackageWithViolatingLicense(Package $package): void;
 
     public function onUnlicensedPackageNotExplicitlyAllowed(Package $package): void;
 

--- a/src/Output/DisplayOutputSubscriber.php
+++ b/src/Output/DisplayOutputSubscriber.php
@@ -53,7 +53,7 @@ final class DisplayOutputSubscriber implements Subscriber
 
     private function onPackageWithViolatingLicense(PackageWithViolatingLicense $event): void
     {
-        $this->display->onPackageWithViolatingLicense($event->package, $event->license);
+        $this->display->onPackageWithViolatingLicense($event->package);
     }
 
     private function onUnlicensedPackageNotExplicitlyAllowed(UnlicensedPackageNotExplicitlyAllowed $event): void

--- a/src/Output/HumanReadableDisplay.php
+++ b/src/Output/HumanReadableDisplay.php
@@ -37,13 +37,13 @@ final class HumanReadableDisplay implements Display
         $this->style->success('All dependencies have allowed licenses.');
     }
 
-    public function onPackageWithViolatingLicense(Package $package, string $license): void
+    public function onPackageWithViolatingLicense(Package $package): void
     {
         $this->style->error(
             \sprintf(
-                'Dependency "%s" has license "%s" which is not in the allowed list.',
+                'Dependency "%s" is licensed under "%s" which is not in the allowed list.',
                 $package->name->toString(),
-                $license,
+                $package->licenses->toString(),
             ),
         );
     }

--- a/src/Output/HumanReadableDisplay.php
+++ b/src/Output/HumanReadableDisplay.php
@@ -39,13 +39,23 @@ final class HumanReadableDisplay implements Display
 
     public function onPackageWithViolatingLicense(Package $package): void
     {
-        $this->style->error(
-            \sprintf(
-                'Dependency "%s" is licensed under "%s" which is not in the allowed list.',
-                $package->name->toString(),
-                $package->licenses->toString(),
-            ),
-        );
+        if ($package->licenses->isDisjunctive()) {
+            $this->style->error(
+                \sprintf(
+                    'Dependency "%s" is licensed under any of "%s", none of which are allowed.',
+                    $package->name->toString(),
+                    $package->licenses->toString(),
+                ),
+            );
+        } else {
+            $this->style->error(
+                \sprintf(
+                    'Dependency "%s" is licensed under "%s" which is not in the allowed list.',
+                    $package->name->toString(),
+                    $package->licenses->toString(),
+                ),
+            );
+        }
     }
 
     public function onUnlicensedPackageNotExplicitlyAllowed(Package $package): void

--- a/src/Output/JsonDisplay.php
+++ b/src/Output/JsonDisplay.php
@@ -45,7 +45,9 @@ final class JsonDisplay implements Display
 
     public function onPackageWithViolatingLicense(Package $package): void
     {
-        $this->violations[$package->licenses->toString()][] = $package->name->toString();
+        /** @var non-empty-string $licences */
+        $licences = $package->licenses->toString();
+        $this->violations[$licences][] = $package->name->toString();
     }
 
     public function onUnlicensedPackageNotExplicitlyAllowed(Package $package): void

--- a/src/Output/JsonDisplay.php
+++ b/src/Output/JsonDisplay.php
@@ -43,9 +43,9 @@ final class JsonDisplay implements Display
         );
     }
 
-    public function onPackageWithViolatingLicense(Package $package, string $license): void
+    public function onPackageWithViolatingLicense(Package $package): void
     {
-        $this->violations[$license][] = $package->name->toString();
+        $this->violations[$package->licenses->toString()][] = $package->name->toString();
     }
 
     public function onUnlicensedPackageNotExplicitlyAllowed(Package $package): void

--- a/src/Package.php
+++ b/src/Package.php
@@ -6,12 +6,9 @@ namespace Lendable\ComposerLicenseChecker;
 
 final class Package
 {
-    /**
-     * @param list<non-empty-string> $licenses
-     */
     public function __construct(
         public readonly PackageName $name,
-        public readonly array $licenses,
+        public readonly Licenses $licenses,
     ) {
     }
 }

--- a/src/Package.php
+++ b/src/Package.php
@@ -11,4 +11,9 @@ final class Package
         public readonly Licenses $licenses,
     ) {
     }
+
+    public function isUnlicensed(): bool
+    {
+        return $this->licenses->isEmpty();
+    }
 }

--- a/src/PackagesProvider/ComposerInstalledJsonPackagesProvider.php
+++ b/src/PackagesProvider/ComposerInstalledJsonPackagesProvider.php
@@ -79,16 +79,16 @@ final class ComposerInstalledJsonPackagesProvider implements PackagesProvider
                             throw FailedProvidingPackages::withReason('Key "name" is not a string');
                         }
 
-                        $licensesArray = $package['license'] ?? [];
+                        $licenses = $package['license'] ?? [];
 
-                        if (!\is_array($licensesArray) || !\array_is_list($licensesArray)) {
+                        if (!\is_array($licenses) || !\array_is_list($licenses)) {
                             throw FailedProvidingPackages::withReason('Key "license" is not a list');
                         }
 
                         /** @var PackageData $package */
                         return new Package(
                             new PackageName($package['name']),
-                            new Licenses($licensesArray),
+                            new Licenses($licenses),
                         );
                     },
                     $dependencies,

--- a/src/PackagesProvider/ComposerInstalledJsonPackagesProvider.php
+++ b/src/PackagesProvider/ComposerInstalledJsonPackagesProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lendable\ComposerLicenseChecker\PackagesProvider;
 
 use Lendable\ComposerLicenseChecker\Exception\FailedProvidingPackages;
+use Lendable\ComposerLicenseChecker\Licenses;
 use Lendable\ComposerLicenseChecker\Package;
 use Lendable\ComposerLicenseChecker\PackageName;
 use Lendable\ComposerLicenseChecker\Packages;
@@ -78,17 +79,16 @@ final class ComposerInstalledJsonPackagesProvider implements PackagesProvider
                             throw FailedProvidingPackages::withReason('Key "name" is not a string');
                         }
 
-                        $licenses = $package['license'] ?? [];
+                        $licensesArray = $package['license'] ?? [];
 
-                        if (!\is_array($licenses) || !\array_is_list($licenses)) {
+                        if (!\is_array($licensesArray) || !\array_is_list($licensesArray)) {
                             throw FailedProvidingPackages::withReason('Key "license" is not a list');
                         }
 
-                        /** @var list<non-empty-string> $licenses */
                         /** @var PackageData $package */
                         return new Package(
                             new PackageName($package['name']),
-                            $licenses,
+                            new Licenses($licensesArray),
                         );
                     },
                     $dependencies,

--- a/src/PackagesProvider/ComposerLicensesPackagesProvider.php
+++ b/src/PackagesProvider/ComposerLicensesPackagesProvider.php
@@ -7,6 +7,7 @@ namespace Lendable\ComposerLicenseChecker\PackagesProvider;
 use Lendable\ComposerLicenseChecker\ComposerRunner;
 use Lendable\ComposerLicenseChecker\Exception\FailedProvidingPackages;
 use Lendable\ComposerLicenseChecker\Exception\FailedRunningComposer;
+use Lendable\ComposerLicenseChecker\Licenses;
 use Lendable\ComposerLicenseChecker\Package;
 use Lendable\ComposerLicenseChecker\PackageName;
 use Lendable\ComposerLicenseChecker\Packages;
@@ -45,7 +46,7 @@ final class ComposerLicensesPackagesProvider implements PackagesProvider
 
         return new Packages(
             \array_map(
-                static fn (string $name, array $package): Package => new Package(new PackageName($name), $package['license']),
+                static fn (string $name, array $package): Package => new Package(new PackageName($name), new Licenses($package['license'])),
                 \array_keys($data['dependencies']),
                 $data['dependencies'],
             ),

--- a/tests/e2e/LicenseCheckerCase.php
+++ b/tests/e2e/LicenseCheckerCase.php
@@ -155,7 +155,6 @@ abstract class LicenseCheckerCase extends TestCase
             ->foundLicensingIssues(
                 [
                     'lendable/apache' => 'Apache-2.0',
-                    'lendable/bsd3_mit' => 'BSD-3-Clause',
                     'package/bsd3' => 'BSD-3-Clause',
                 ],
             );

--- a/tests/e2e/LicenseCheckerCase.php
+++ b/tests/e2e/LicenseCheckerCase.php
@@ -57,7 +57,7 @@ abstract class LicenseCheckerCase extends TestCase
         $handle = $this->createTempFile();
         $allowFile = LicenseConfigurationFileBuilder::create($handle)->build();
 
-        $this->commandTester->execute(['--allow-file' => $allowFile, '--path' => '../']);
+        $this->commandTester->execute(['--allow-file' => $allowFile, '--path' => __DIR__]);
 
         CommandTesterAsserter::assertThat($this->commandTester)
             ->hasStatusCode(1)

--- a/tests/e2e/LicenseCheckerCase.php
+++ b/tests/e2e/LicenseCheckerCase.php
@@ -57,7 +57,7 @@ abstract class LicenseCheckerCase extends TestCase
         $handle = $this->createTempFile();
         $allowFile = LicenseConfigurationFileBuilder::create($handle)->build();
 
-        $this->commandTester->execute(['--allow-file' => $allowFile, '--path' => __DIR__]);
+        $this->commandTester->execute(['--allow-file' => $allowFile, '--path' => '../']);
 
         CommandTesterAsserter::assertThat($this->commandTester)
             ->hasStatusCode(1)

--- a/tests/e2e/Output/DisplayOutputSubscriberTest.php
+++ b/tests/e2e/Output/DisplayOutputSubscriberTest.php
@@ -12,6 +12,7 @@ use Lendable\ComposerLicenseChecker\Event\PackageWithViolatingLicense;
 use Lendable\ComposerLicenseChecker\Event\Started;
 use Lendable\ComposerLicenseChecker\Event\TraceInformation;
 use Lendable\ComposerLicenseChecker\Event\UnlicensedPackageNotExplicitlyAllowed;
+use Lendable\ComposerLicenseChecker\Licenses;
 use Lendable\ComposerLicenseChecker\Output\Display;
 use Lendable\ComposerLicenseChecker\Output\DisplayOutputSubscriber;
 use Lendable\ComposerLicenseChecker\Package;
@@ -75,20 +76,19 @@ final class DisplayOutputSubscriberTest extends TestCase
 
     public function test_delegates_on_package_with_violating_license(): void
     {
-        $package = new Package(new PackageName('foo/bar'), ['MIT']);
-        $license = 'MIT';
+        $package = new Package(new PackageName('foo/bar'), new Licenses(['MIT']));
 
         $this->display
             ->expects(self::once())
             ->method('onPackageWithViolatingLicense')
-            ->with($package, $license);
+            ->with($package);
 
-        $this->dispatcher->dispatch(new PackageWithViolatingLicense($package, $license));
+        $this->dispatcher->dispatch(new PackageWithViolatingLicense($package));
     }
 
     public function test_delegates_on_unlicensed_package_not_explicitly_allowed(): void
     {
-        $package = new Package(new PackageName('foo/bar'), ['MIT']);
+        $package = new Package(new PackageName('foo/bar'), new Licenses(['MIT']));
 
         $this->display
             ->expects(self::once())

--- a/tests/support/CommandTesterAsserter.php
+++ b/tests/support/CommandTesterAsserter.php
@@ -81,14 +81,14 @@ final class CommandTesterAsserter
             }
 
             if (\is_array($license)) {
-                foreach ($license as $element) {
-                    $expectedOutput[] = \sprintf(
-                        ' [ERROR] Dependency "%s" has license "%s" which is not in the allowed list.',
-                        $package,
-                        $element,
-                    );
-                    $expectedOutput[] = '';
-                }
+
+                $expectedOutput[] = \sprintf(
+                    ' [ERROR] Dependency "%s" is licensed under "%s" which is not in the allowed list.',
+                    $package,
+                    \implode(', ', $license),
+                );
+                $expectedOutput[] = '';
+
             } else {
                 $expectedOutput[] = \sprintf(
                     ' [ERROR] Dependency "%s" does not have a license and is not explicitly allowed.',

--- a/tests/support/CommandTesterAsserter.php
+++ b/tests/support/CommandTesterAsserter.php
@@ -81,12 +81,21 @@ final class CommandTesterAsserter
             }
 
             if (\is_array($license)) {
-                $expectedOutput[] = \sprintf(
-                    ' [ERROR] Dependency "%s" is licensed under "%s" which is not in the allowed list.',
-                    $package,
-                    \implode(', ', $license),
-                );
-                $expectedOutput[] = '';
+                if (\count($license) > 1) {
+                    $expectedOutput[] = \sprintf(
+                        ' [ERROR] Dependency "%s" is licensed under any of "%s", none of which are allowed.',
+                        $package,
+                        \implode(', ', $license),
+                    );
+                    $expectedOutput[] = '';
+                } else {
+                    $expectedOutput[] = \sprintf(
+                        ' [ERROR] Dependency "%s" is licensed under "%s" which is not in the allowed list.',
+                        $package,
+                        \implode(', ', $license),
+                    );
+                    $expectedOutput[] = '';
+                }
             } else {
                 $expectedOutput[] = \sprintf(
                     ' [ERROR] Dependency "%s" does not have a license and is not explicitly allowed.',

--- a/tests/support/CommandTesterAsserter.php
+++ b/tests/support/CommandTesterAsserter.php
@@ -81,14 +81,12 @@ final class CommandTesterAsserter
             }
 
             if (\is_array($license)) {
-
                 $expectedOutput[] = \sprintf(
                     ' [ERROR] Dependency "%s" is licensed under "%s" which is not in the allowed list.',
                     $package,
                     \implode(', ', $license),
                 );
                 $expectedOutput[] = '';
-
             } else {
                 $expectedOutput[] = \sprintf(
                     ' [ERROR] Dependency "%s" does not have a license and is not explicitly allowed.',

--- a/tests/support/PackageAsserter.php
+++ b/tests/support/PackageAsserter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Support\Lendable\ComposerLicenseChecker;
 
+use Lendable\ComposerLicenseChecker\Licenses;
 use Lendable\ComposerLicenseChecker\Package;
 use Lendable\ComposerLicenseChecker\PackageName;
 use PHPUnit\Framework\Assert;
@@ -30,32 +31,25 @@ final class PackageAsserter
         return $this;
     }
 
-    public function hasLicense(string $license): self
-    {
-        Assert::assertContains($license, $this->package->licenses);
-
-        return $this;
-    }
-
-    /**
-     * @param list<string> $licenses
-     */
-    public function hasExactLicenses(array $licenses): self
-    {
-        Assert::assertSameSize($licenses, $this->package->licenses);
-
-        foreach ($licenses as $license) {
-            $this->hasLicense($license);
-        }
-
-        return $this;
-    }
-
     public function equals(Package $package): self
     {
         $this->hasName($package->name);
         $this->hasExactLicenses($package->licenses);
 
         return $this;
+    }
+
+    private function hasExactLicenses(Licenses $licenses): void
+    {
+        Assert::assertSameSize($licenses, $this->package->licenses);
+
+        foreach ($licenses as $license) {
+            $this->hasLicense($license);
+        }
+    }
+
+    private function hasLicense(string $license): void
+    {
+        Assert::assertContains($license, \explode(', ', $this->package->licenses->toString()));
     }
 }

--- a/tests/support/PackagesAsserter.php
+++ b/tests/support/PackagesAsserter.php
@@ -18,16 +18,6 @@ final class PackagesAsserter
         return new self($packages);
     }
 
-    /**
-     * @param \Countable|array<mixed> $countable
-     */
-    private function sameSize(\Countable|array $countable): self
-    {
-        Assert::assertSameSize($countable, $this->packages);
-
-        return $this;
-    }
-
     public function equals(Packages $packages): self
     {
         $this->sameSize($packages);
@@ -39,6 +29,16 @@ final class PackagesAsserter
         foreach ($iterator as [$expected, $actual]) {
             PackageAsserter::assertThat($actual)->equals($expected);
         }
+
+        return $this;
+    }
+
+    /**
+     * @param \Countable|array<mixed> $countable
+     */
+    private function sameSize(\Countable|array $countable): self
+    {
+        Assert::assertSameSize($countable, $this->packages);
 
         return $this;
     }

--- a/tests/support/PackagesAsserter.php
+++ b/tests/support/PackagesAsserter.php
@@ -18,17 +18,10 @@ final class PackagesAsserter
         return new self($packages);
     }
 
-    public function hasCount(int $count): self
-    {
-        Assert::assertCount($count, $this->packages);
-
-        return $this;
-    }
-
     /**
      * @param \Countable|array<mixed> $countable
      */
-    public function sameSize(\Countable|array $countable): self
+    private function sameSize(\Countable|array $countable): self
     {
         Assert::assertSameSize($countable, $this->packages);
 

--- a/tests/support/PackagesAsserter.php
+++ b/tests/support/PackagesAsserter.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Support\Lendable\ComposerLicenseChecker;
 
-use Lendable\ComposerLicenseChecker\Package;
 use Lendable\ComposerLicenseChecker\Packages;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\AssertionFailedError;
 
 final class PackagesAsserter
 {
@@ -35,26 +33,6 @@ final class PackagesAsserter
         Assert::assertSameSize($countable, $this->packages);
 
         return $this;
-    }
-
-    public function containsPackage(Package $package): self
-    {
-        foreach ($this->packages as $existing) {
-            try {
-                PackageAsserter::assertThat($existing)->equals($package);
-
-                return $this;
-            } catch (AssertionFailedError) {
-            }
-        }
-
-        Assert::fail(
-            \sprintf(
-                'Failed to find a package with name "%s" and licenses [%s].',
-                $package->name->toString(),
-                \implode(', ', $package->licenses),
-            ),
-        );
     }
 
     public function equals(Packages $packages): self

--- a/tests/unit/PackagesProvider/ComposerInstalledJsonPackagesProviderTest.php
+++ b/tests/unit/PackagesProvider/ComposerInstalledJsonPackagesProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Lendable\ComposerLicenseChecker\PackagesProvider;
 
 use Lendable\ComposerLicenseChecker\Exception\FailedProvidingPackages;
+use Lendable\ComposerLicenseChecker\Licenses;
 use Lendable\ComposerLicenseChecker\Package;
 use Lendable\ComposerLicenseChecker\PackageName;
 use Lendable\ComposerLicenseChecker\Packages;
@@ -51,7 +52,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
                 'dev-package-names' => [],
                 'packages' => [['name' => 'foo/bar', 'version' => '1.0.0', 'license' => ['MIT']]],
             ],
-            new Packages([new Package(new PackageName('foo/bar'), ['MIT'])]),
+            new Packages([new Package(new PackageName('foo/bar'), new Licenses(['MIT']))]),
             true,
         ];
         yield 'ignoring dev with 1 dev dependency' => [
@@ -69,7 +70,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
                 'dev-package-names' => ['foo/bar'],
                 'packages' => [['name' => 'foo/bar', 'version' => '1.0.0', 'license' => ['MIT']]],
             ],
-            new Packages([new Package(new PackageName('foo/bar'), ['MIT'])]),
+            new Packages([new Package(new PackageName('foo/bar'), new Licenses(['MIT']))]),
             false,
         ];
         yield 'not ignoring dev with 1 dev dependency and 1 runtime' => [
@@ -82,8 +83,8 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
                 ],
             ],
             new Packages([
-                new Package(new PackageName('foo/bar'), ['MIT']),
-                new Package(new PackageName('foo/baz'), ['MIT', 'Apache-2.0']),
+                new Package(new PackageName('foo/bar'), new Licenses(['MIT'])),
+                new Package(new PackageName('foo/baz'), new Licenses(['MIT', 'Apache-2.0'])),
             ]),
             false,
         ];
@@ -97,7 +98,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
                 ],
             ],
             new Packages([
-                new Package(new PackageName('foo/baz'), ['MIT', 'Apache-2.0']),
+                new Package(new PackageName('foo/baz'), new Licenses(['MIT', 'Apache-2.0'])),
             ]),
             true,
         ];
@@ -111,7 +112,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
                 ],
             ],
             new Packages([
-                new Package(new PackageName('foo/bar'), []),
+                new Package(new PackageName('foo/bar'), new Licenses([])),
             ]),
             true,
         ];

--- a/tests/unit/PackagesProvider/ComposerInstalledJsonPackagesProviderTest.php
+++ b/tests/unit/PackagesProvider/ComposerInstalledJsonPackagesProviderTest.php
@@ -138,7 +138,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
 
         $this->expectExceptionObject(
             FailedProvidingPackages::withReason(
-                \sprintf('File "%s" not found', \realpath($this->projectPath).'/vendor/composer/installed.json'),
+                \sprintf('File "%s" not found', $this->projectPath.'/vendor/composer/installed.json'),
             ),
         );
 
@@ -153,7 +153,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
 
         $this->expectExceptionObject(
             FailedProvidingPackages::withReason(
-                \sprintf('File "%s" is not readable', \realpath($this->projectPath).'/vendor/composer/installed.json'),
+                \sprintf('File "%s" is not readable', $this->projectPath.'/vendor/composer/installed.json'),
             ),
         );
 

--- a/tests/unit/PackagesProvider/ComposerInstalledJsonPackagesProviderTest.php
+++ b/tests/unit/PackagesProvider/ComposerInstalledJsonPackagesProviderTest.php
@@ -138,7 +138,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
 
         $this->expectExceptionObject(
             FailedProvidingPackages::withReason(
-                \sprintf('File "%s" not found', $this->projectPath.'/vendor/composer/installed.json'),
+                \sprintf('File "%s" not found', \realpath($this->projectPath).'/vendor/composer/installed.json'),
             ),
         );
 
@@ -153,7 +153,7 @@ final class ComposerInstalledJsonPackagesProviderTest extends TestCase
 
         $this->expectExceptionObject(
             FailedProvidingPackages::withReason(
-                \sprintf('File "%s" is not readable', $this->projectPath.'/vendor/composer/installed.json'),
+                \sprintf('File "%s" is not readable', \realpath($this->projectPath).'/vendor/composer/installed.json'),
             ),
         );
 

--- a/tests/unit/PackagesProvider/ComposerLicensesPackagesProviderTest.php
+++ b/tests/unit/PackagesProvider/ComposerLicensesPackagesProviderTest.php
@@ -35,10 +35,10 @@ final class ComposerLicensesPackagesProviderTest extends TestCase
 
         self::assertCount(2, $packages);
         self::assertSame('vendor/project', $packages[0]->name->toString());
-        self::assertSame(['MIT', 'LGPL'], $packages[0]->licenses);
+        self::assertSame('MIT, LGPL', $packages[0]->licenses->toString());
 
         self::assertSame('vendor2/project', $packages[1]->name->toString());
-        self::assertSame(['WTFPL'], $packages[1]->licenses);
+        self::assertSame('WTFPL', $packages[1]->licenses->toString());
     }
 
     public function test_wraps_and_throws_composer_runner_failure(): void

--- a/tests/unit/PackagesTest.php
+++ b/tests/unit/PackagesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Lendable\ComposerLicenseChecker;
 
+use Lendable\ComposerLicenseChecker\Licenses;
 use Lendable\ComposerLicenseChecker\Package;
 use Lendable\ComposerLicenseChecker\PackageName;
 use Lendable\ComposerLicenseChecker\Packages;
@@ -14,9 +15,9 @@ final class PackagesTest extends TestCase
     public function test_returns_instance_with_sorted_packages(): void
     {
         $packages = new Packages([
-            new Package(new PackageName('c/d'), []),
-            new Package(new PackageName('x/y'), []),
-            new Package(new PackageName('c/b'), []),
+            new Package(new PackageName('c/d'), new Licenses([])),
+            new Package(new PackageName('x/y'), new Licenses([])),
+            new Package(new PackageName('c/b'), new Licenses([])),
         ]);
 
         $sorted = $packages->sort();
@@ -31,10 +32,10 @@ final class PackagesTest extends TestCase
     public function test_returns_count(): void
     {
         self::assertCount(0, new Packages([]));
-        self::assertCount(1, new Packages([new Package(new PackageName('a/b'), [])]));
+        self::assertCount(1, new Packages([new Package(new PackageName('a/b'), new Licenses([]))]));
         self::assertCount(2, new Packages([
-            new Package(new PackageName('a/a'), []),
-            new Package(new PackageName('a/b'), []),
+            new Package(new PackageName('a/a'), new Licenses([])),
+            new Package(new PackageName('a/b'), new Licenses([])),
         ]));
     }
 }


### PR DESCRIPTION
This PR fixes the behavior with a disjunctive license (e.g. "MIT, WTFPL, GPL-3.0-only").

Disjunctive license means that the user can choose any license from the list. Therefore, `composer-license-checker` should allow the package if _at least one_ license is allowed. Before, it was checking all licenses from the list and demanding all of them to be allowed.