### PR TITLE
Set Composer's PHP version based on CI matrix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
           ini-values: memory_limit=-1
           tools: "composer:${{ matrix.composer-version }}"
 
+      - name: "Update Composer platform version"
+        if: ${{ matrix.dependencies != 'locked' && matrix.php-version != '8.1' }}
+        shell: bash
+        run: "composer config platform.php ${{ matrix.php-version }}"
+
       - uses: "ramsey/composer-install@v2"
         with:
           dependency-versions: "${{ matrix.dependencies }}"


### PR DESCRIPTION
Enables testing against a wider dependency range, the platform version is only set to constrain Renovate to bumping dependency ranges to those supporting the minimum PHP version supported.