### PR TITLE
Validate allow file for non-PHP content

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
          cacheResultFile="tmp/.phpunit.result.cache"
          bootstrap="tests/bootstrap.php">
 

--- a/src/LicenseChecker.php
+++ b/src/LicenseChecker.php
@@ -98,12 +98,30 @@ final class LicenseChecker extends SingleCommandApplication
             return self::FAILURE;
         }
 
+        \ob_start();
         $config = require $input->getOption('allow-file');
+        $outputBuffer = \ob_get_contents();
+        \ob_end_clean();
+
         if (!$config instanceof LicenseConfiguration) {
             $this->dispatcher->dispatch(
                 new FatalError(
                     \sprintf(
                         'File "%s" must return an instance of %s.',
+                        $allowFile,
+                        LicenseConfiguration::class,
+                    ),
+                ),
+            );
+
+            return self::FAILURE;
+        }
+
+        if ($outputBuffer !== '' && $outputBuffer !== false) {
+            $this->dispatcher->dispatch(
+                new FatalError(
+                    \sprintf(
+                        'File "%s" returned an instance of %s, but also output plain text due to content outside PHP tags.',
                         $allowFile,
                         LicenseConfiguration::class,
                     ),

--- a/tests/data/default/allowed_licenses_with_text.php
+++ b/tests/data/default/allowed_licenses_with_text.php
@@ -1,0 +1,8 @@
+ShouldNotAppearInOutput
+<?php
+
+use Lendable\ComposerLicenseChecker\LicenseConfigurationBuilder;
+
+return (new LicenseConfigurationBuilder())
+    ->addLicenses('BSD-3-Clause', 'MIT')
+    ->build();

--- a/tests/data/default/invalid_allowed_licenses.txt
+++ b/tests/data/default/invalid_allowed_licenses.txt
@@ -1,0 +1,1 @@
+ShouldNotAppearInOutput

--- a/tests/e2e/LicenseCheckerCase.php
+++ b/tests/e2e/LicenseCheckerCase.php
@@ -80,6 +80,40 @@ abstract class LicenseCheckerCase extends TestCase
             );
     }
 
+    public function test_failure_with_invalid_allowed_licenses_file_containing_only_text(): void
+    {
+        $this->commandTester->execute([
+            '--allow-file' => 'tests/data/default/invalid_allowed_licenses.txt',
+            '--path' => $this->path,
+        ]);
+
+        CommandTesterAsserter::assertThat($this->commandTester)
+            ->doesNotContainInStdout('ShouldNotAppearInOutput')
+            ->encounteredError(
+                \sprintf(
+                    "File \"tests/data/default/invalid_allowed_licenses.txt\" must return an instance of\n         %s.",
+                    LicenseConfiguration::class,
+                ),
+            );
+    }
+
+    public function test_failure_with_allowed_licenses_file_containing_config_and_text(): void
+    {
+        $this->commandTester->execute([
+            '--allow-file' => 'tests/data/default/allowed_licenses_with_text.php',
+            '--path' => $this->path,
+        ]);
+
+        CommandTesterAsserter::assertThat($this->commandTester)
+            ->doesNotContainInStdout('ShouldNotAppearInOutput')
+            ->encounteredError(
+                \sprintf(
+                    "File \"tests/data/default/allowed_licenses_with_text.php\" returned an instance of\n         %s, but also output plain text due to content outside PHP\n         tags.",
+                    LicenseConfiguration::class,
+                ),
+            );
+    }
+
     public function test_failure_with_invalid_output_format(): void
     {
         $handle = $this->createTempFile();

--- a/tests/support/CommandTesterAsserter.php
+++ b/tests/support/CommandTesterAsserter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Support\Lendable\ComposerLicenseChecker;
 
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class CommandTesterAsserter
@@ -141,11 +140,8 @@ final class CommandTesterAsserter
     public function containsInStdout(string $fragment): self
     {
         foreach ($this->normalizedStdoutLines() as $line) {
-            try {
-                Assert::assertStringContainsString($fragment, $line);
-
+            if (\str_contains($line, $fragment)) {
                 return $this;
-            } catch (AssertionFailedError) {
             }
         }
 
@@ -156,6 +152,26 @@ final class CommandTesterAsserter
                 $this->normalizedStdout(),
             ),
         );
+    }
+
+    /**
+     * @param non-empty-string $fragment
+     */
+    public function doesNotContainInStdout(string $fragment): self
+    {
+        foreach ($this->normalizedStdoutLines() as $line) {
+            if (\str_contains($line, $fragment)) {
+                Assert::fail(
+                    \sprintf(
+                        "Output contained unexpected \"%s\". Output\n: %s",
+                        $fragment,
+                        $this->normalizedStdout(),
+                    ),
+                );
+            }
+        }
+
+        return $this;
     }
 
     private function normalizedStdout(): string


### PR DESCRIPTION
As we're just requiring the allow file, it can result in file contents being output to screen if any content is outside `<?php` tags. This is harmless but extra noise. This PR:

* Enables strict mode for tests writing output in PHPUnit and fails on risky tests.
* Uses output buffering when requiring the allow file to detect any output.