### PR TITLE
Reset trace information in `JsonDisplay` during `onStarted`

### DIFF
--- a/src/Output/JsonDisplay.php
+++ b/src/Output/JsonDisplay.php
@@ -31,6 +31,7 @@ final class JsonDisplay implements Display
     public function onStarted(): void
     {
         $this->violations = [];
+        $this->trace = [];
     }
 
     public function onFatalError(string $message): void


### PR DESCRIPTION
`onStarted` is intended to act as a reset of state such that a `JsonDisplay` could be re-used, due to the execution model this never happens so this is purely code cleanliness and not a bug fix.