### PR TITLE
Ensure an assertion is recorded for positive cases in `CommandTesterAsserter`

### DIFF
--- a/tests/support/CommandTesterAsserter.php
+++ b/tests/support/CommandTesterAsserter.php
@@ -141,6 +141,8 @@ final class CommandTesterAsserter
     {
         foreach ($this->normalizedStdoutLines() as $line) {
             if (\str_contains($line, $fragment)) {
+                Assert::assertThat(true, Assert::isTrue()); // Ensure an assertion is recorded.
+
                 return $this;
             }
         }
@@ -170,6 +172,8 @@ final class CommandTesterAsserter
                 );
             }
         }
+
+        Assert::assertThat(true, Assert::isTrue()); // Ensure an assertion is recorded.
 
         return $this;
     }


### PR DESCRIPTION
This is the easiest way I can think of, `Assert:assertTrue(true)` will upset PHPStan, and there's no API in PHPUnit to increment the assertion counter via `Assert`, only `TestCase`.

This aims to ensure PHPUnit is not upset at a test not performing any assertions.