### PR TITLE
Fix merge gatekeeper on PRs

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -14,12 +14,7 @@ jobs:
       statuses: read
     steps:
       - name: Run Merge Gatekeeper
-        if: ${{ github.event_name == 'merge_group' }}
         uses: upsidr/merge-gatekeeper@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.sha }}
-      - name: Run Merge Gatekeeper
-        uses: upsidr/merge-gatekeeper@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -14,7 +14,12 @@ jobs:
       statuses: read
     steps:
       - name: Run Merge Gatekeeper
+        if: ${{ github.event_name == 'merge_group' }}
         uses: upsidr/merge-gatekeeper@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.sha }}
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`github.ref` breaks PRs, but works for merge queues, make it conditional.

See https://github.com/upsidr/merge-gatekeeper/issues/71