### PR TITLE
chore: use `ob_get_clean()` over `ob_get_contents()` and `ob_end_clean()`

### DIFF
--- a/src/LicenseChecker.php
+++ b/src/LicenseChecker.php
@@ -102,8 +102,7 @@ final class LicenseChecker extends SingleCommandApplication
 
         \ob_start();
         $config = require $input->getOption('allow-file');
-        $outputBuffer = \ob_get_contents();
-        \ob_end_clean();
+        $outputBuffer = \ob_get_clean();
 
         if (!$config instanceof LicenseConfiguration) {
             $this->dispatcher->dispatch(


### PR DESCRIPTION
Functionally equivalent in this use case but typically best practice.